### PR TITLE
Manually set the sym link for npm

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -54,6 +54,7 @@ cp -a $SALESFORCE_CACHE_DIR/node $SALESFORCE_DIR/node
 export PATH="$SALESFORCE_DIR/node/bin":$PATH
 echo $PATH
 ls -l $SALESFORCE_DIR
+ln -s -f $SALESFORCE_DIR/node/lib/node_modules/npm/bin/npm-cli.js $SALESFORCE_DIR/node/bin/npm
 ls -l $SALESFORCE_DIR/node/bin
 
 cp -R $BP_DIR/lib/* $SALESFORCE_DIR/

--- a/bin/compile
+++ b/bin/compile
@@ -52,8 +52,8 @@ install_nodejs $SALESFORCE_CACHE_DIR
 # Put node in build dir since the cache is not available at time of deploy
 cp -a $SALESFORCE_CACHE_DIR/node $SALESFORCE_DIR/node
 export PATH="$SALESFORCE_DIR/node/bin":$PATH
-echo $PATH
-ls -l $SALESFORCE_DIR
+
+### Hardcode the npm sym link to get around a Heroku CI cache bug. This should be removed when fixed.
 ln -s -f $SALESFORCE_DIR/node/lib/node_modules/npm/bin/npm-cli.js $SALESFORCE_DIR/node/bin/npm
 ls -l $SALESFORCE_DIR/node/bin
 

--- a/bin/compile
+++ b/bin/compile
@@ -52,6 +52,9 @@ install_nodejs $SALESFORCE_CACHE_DIR
 # Put node in build dir since the cache is not available at time of deploy
 cp -a $SALESFORCE_CACHE_DIR/node $SALESFORCE_DIR/node
 export PATH="$SALESFORCE_DIR/node/bin":$PATH
+echo $PATH
+ls -l $SALESFORCE_DIR
+ls -l $SALESFORCE_DIR/node/bin
 
 cp -R $BP_DIR/lib/* $SALESFORCE_DIR/
 cp $BP_DIR/package.json $SALESFORCE_DIR/package.json


### PR DESCRIPTION
This works around a Heroku CI caching bug.
