### PR TITLE
Package installation with --noprompt

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -111,6 +111,7 @@ debug "data-plans: $data_plans"
 devHubAuthFile=$BUILD_DIR/$vendorDir/sfdxurl
 
 # Review App or CI
+debug "Stage: $STAGE"
 if [ "$STAGE" == "" ]; then
 
   log "Running as a REVIEW APP ..."

--- a/bin/compile
+++ b/bin/compile
@@ -165,7 +165,7 @@ then
     debug "SFDX_PACKAGE2_VERSION_ID: $SFDX_PACKAGE2_VERSION_ID"
     
     # get package version id
-    CMD="sfdx force:package2:version:create:get -i $SFDX_PACKAGE2_VERSION_ID --json | jq -r .result.SubscriberPackageVersionId"
+    CMD="sfdx force:package2:version:create:list --json | jq '.result[] | select((.Id) == \"$SFDX_PACKAGE2_VERSION_ID\")' | jq -r .SubscriberPackageVersionId"
     SFDX_PACKAGE_VERSION_ID=$(eval $CMD)
     debug "SFDX_PACKAGE_VERSION_ID: $SFDX_PACKAGE_VERSION_ID"
 

--- a/bin/compile
+++ b/bin/compile
@@ -139,7 +139,7 @@ if [ "$STAGE" == "DEV" ]; then
 fi
 
 # Create a package is specied and it's not a review app
-if [ "$SFDX_CREATE_PACKAGE_VERSION" == "true" ] && [ ! "$STAGE" == "DEV" ];
+if [ "$SFDX_CREATE_PACKAGE_VERSION" == "true" ] && [ ! "$STAGE" == "" ];
 then
 
   log "Auth to dev hub ..."

--- a/bin/compile
+++ b/bin/compile
@@ -160,7 +160,12 @@ then
     log "Creating new package version (this may take awhile) ..."
 
     # create package version
-    CMD="sfdx force:package2:version:create -i $SFDX_PACKAGE_ID --wait 100 --json | jq -r .result.SubscriberPackageVersionId"
+    CMD="sfdx force:package2:version:create -i $SFDX_PACKAGE_ID --wait 100 --json | jq -r .result.Id"
+    SFDX_PACKAGE2_VERSION_ID=$(eval $CMD)
+    debug "SFDX_PACKAGE2_VERSION_ID: $SFDX_PACKAGE2_VERSION_ID"
+    
+    # get package version id
+    CMD="sfdx force:package2:version:create:get -i $SFDX_PACKAGE2_VERSION_ID --json | jq -r .result.SubscriberPackageVersionId"
     SFDX_PACKAGE_VERSION_ID=$(eval $CMD)
     debug "SFDX_PACKAGE_VERSION_ID: $SFDX_PACKAGE_VERSION_ID"
 
@@ -249,7 +254,7 @@ fi
 if [ ! -f $BUILD_DIR/Procfile ]; then
   log "Creating Procfile ..."
   echo "# Deploy source to production org.
-release: ./"$vendorDir"/release.sh \"$TARGET_SCRATCH_ORG_ALIAS\" \"$SFDX_PACKAGE_VERSION_ID\"" > $BUILD_DIR/Procfile
+release: ./"$vendorDir"/release.sh \"$TARGET_SCRATCH_ORG_ALIAS\" \"$SFDX_PACKAGE_VERSION_ID\" \"$SFDX_PACKAGE2_VERSION_ID\"" > $BUILD_DIR/Procfile
 
   debug "Generated Procfile that will deploy source in release phase and redirect to open-path in web phase"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -112,7 +112,7 @@ devHubAuthFile=$BUILD_DIR/$vendorDir/sfdxurl
 
 # Review App or CI
 debug "Stage: $STAGE"
-if [ "$STAGE" == "" ]; then
+if [ "$STAGE" == "DEV" ]; then
 
   log "Running as a REVIEW APP ..."
 
@@ -139,7 +139,7 @@ if [ "$STAGE" == "" ]; then
 fi
 
 # Create a package is specied and it's not a review app
-if [ "$SFDX_CREATE_PACKAGE_VERSION" == "true" ] && [ ! "$STAGE" == "" ];
+if [ "$SFDX_CREATE_PACKAGE_VERSION" == "true" ] && [ ! "$STAGE" == "DEV" ];
 then
 
   log "Auth to dev hub ..."

--- a/bin/compile
+++ b/bin/compile
@@ -110,9 +110,8 @@ debug "data-plans: $data_plans"
 # Set path for Dev Hub auth file
 devHubAuthFile=$BUILD_DIR/$vendorDir/sfdxurl
 
-# Review App or CI
-debug "Stage: $STAGE"
-if [ "$STAGE" == "DEV" ]; then
+# Review App or CI / ADDED "STAGE" : "REVIEW" in app.json
+if [ "$STAGE" == "REVIEW" ]; then
 
   log "Running as a REVIEW APP ..."
 
@@ -139,7 +138,7 @@ if [ "$STAGE" == "DEV" ]; then
 fi
 
 # Create a package is specied and it's not a review app
-if [ "$SFDX_CREATE_PACKAGE_VERSION" == "true" ] && [ ! "$STAGE" == "" ];
+if [ "$SFDX_CREATE_PACKAGE_VERSION" == "true" ] && [ ! "$STAGE" == "REVIEW" ];
 then
 
   log "Auth to dev hub ..."

--- a/lib/release.sh
+++ b/lib/release.sh
@@ -111,7 +111,7 @@ if [ ! "$STAGE" == "REVIEW" ]; then
         log "Auth to dev hub ..."
 
         # Authenticate to Dev Hub (for package release)
-        auth "$devHubAuthFile" "$SFDX_DEV_HUB_AUTH_URL" d huborg
+        auth "$vendorDir/sfdxurl" "$SFDX_DEV_HUB_AUTH_URL" d huborg
 
         log "Releasing package version $SFDX_PACKAGE_NAME ..."
 

--- a/lib/release.sh
+++ b/lib/release.sh
@@ -108,7 +108,13 @@ if [ ! "$STAGE" == "REVIEW" ]; then
     then
       if [ "$STAGE" == "PROD" ]; then
         
+        log "Auth to dev hub ..."
+
+        # Authenticate to Dev Hub (for package release)
+        auth "$devHubAuthFile" "$SFDX_DEV_HUB_AUTH_URL" d huborg
+
         log "Releasing package version $SFDX_PACKAGE_NAME ..."
+
         invokeCmd "sfdx force:package2:version:update -i \"$SFDX_PACKAGE_VERSION_ID\"  --setasreleased --noprompt"
         
       fi

--- a/lib/release.sh
+++ b/lib/release.sh
@@ -121,7 +121,7 @@ if [ ! "$STAGE" == "REVIEW" ]; then
         debug "Create package release: $CMD"
         SFDX_VERSION_ID=$(eval $CMD)
         debug "SFDX_VERSION_ID: $SFDX_VERSION_ID"
-        invokeCmd "sfdx force:package2:version:update -i \"$SFDX_VERSION_ID\"  --setasreleased --noprompt"
+        invokeCmd "sfdx force:package2:version:update -i \"$SFDX_VERSION_ID\"  --setasreleased --noprompt -v huborg"
         
       fi
       

--- a/lib/release.sh
+++ b/lib/release.sh
@@ -109,7 +109,7 @@ if [ ! "$STAGE" == "" ]; then
     
       log "Installing package version $SFDX_PACKAGE_NAME ..."
 
-      invokeCmd "sfdx force:package:install -i \"$SFDX_PACKAGE_VERSION_ID\" -u \"$TARGET_SCRATCH_ORG_ALIAS\" --wait 1000 --publishwait 1000"
+      invokeCmd "sfdx force:package:install -i \"$SFDX_PACKAGE_VERSION_ID\" -u \"$TARGET_SCRATCH_ORG_ALIAS\" --wait 1000 --publishwait 1000 --noprompt"
 
     else
 

--- a/lib/release.sh
+++ b/lib/release.sh
@@ -106,10 +106,15 @@ if [ ! "$STAGE" == "REVIEW" ]; then
     # run package install
     if [ ! -f "$pkgVersionInstallScript" ];
     then
-    
-      log "Installing package version $SFDX_PACKAGE_NAME ..."
-
-      invokeCmd "sfdx force:package:install -i \"$SFDX_PACKAGE_VERSION_ID\" -u \"$TARGET_SCRATCH_ORG_ALIAS\" --wait 1000 --publishwait 1000 --noprompt"
+      if [ "$STAGE" == "PROD" ]; then
+        
+        log "Releasing package version $SFDX_PACKAGE_NAME ..."
+        invokeCmd "sfdx force:package2:version:update -i \"$SFDX_PACKAGE_VERSION_ID\"  --setasreleased --noprompt"
+        
+      fi
+      
+        log "Installing package version $SFDX_PACKAGE_NAME ..."
+        invokeCmd "sfdx force:package:install -i \"$SFDX_PACKAGE_VERSION_ID\" -u \"$TARGET_SCRATCH_ORG_ALIAS\" --wait 1000 --publishwait 1000 --noprompt"
 
     else
 

--- a/lib/release.sh
+++ b/lib/release.sh
@@ -117,10 +117,11 @@ if [ ! "$STAGE" == "REVIEW" ]; then
 
         log "Releasing package version $SFDX_PACKAGE_NAME ..."
         # release package
-        CMD="sfdx force:package2:version:create:get -i $SFDX_PACKAGE2_VERSION_ID --json | jq '.result[] | select((.Id) == \"$SFDX_PACKAGE2_VERSION_ID\")' | jq -r .Package2VersionId"
+        CMD="sfdx force:package2:version:create:get -i \"$SFDX_PACKAGE2_VERSION_ID\" --json | jq '.result[] | select((.Id) == \"$SFDX_PACKAGE2_VERSION_ID\")' | jq -r .Package2VersionId"
         debug "Create package release: $CMD"
         SFDX_VERSION_ID=$(eval $CMD)
         debug "SFDX_VERSION_ID: $SFDX_VERSION_ID"
+        debug "Version Update CMD: sfdx force:package2:version:update -i \"$SFDX_VERSION_ID\"  --setasreleased --noprompt -v huborg"
         invokeCmd "sfdx force:package2:version:update -i \"$SFDX_VERSION_ID\"  --setasreleased --noprompt -v huborg"
         
       fi

--- a/lib/release.sh
+++ b/lib/release.sh
@@ -117,7 +117,7 @@ if [ ! "$STAGE" == "REVIEW" ]; then
 
         log "Releasing package version $SFDX_PACKAGE_NAME ..."
         # release package
-        CMD="sfdx force:package2:version:create:get -i $SFDX_PACKAGE2_VERSION_ID --json | jq -r .result.Package2VersionId"
+        CMD="sfdx force:package2:version:create:get -i $SFDX_PACKAGE2_VERSION_ID --json | jq '.result[] | select((.Id) == \"$SFDX_PACKAGE2_VERSION_ID\")' | jq -r .Package2VersionId"
         debug "Create package release: $CMD"
         SFDX_VERSION_ID=$(eval $CMD)
         debug "SFDX_VERSION_ID: $SFDX_VERSION_ID"

--- a/lib/release.sh
+++ b/lib/release.sh
@@ -42,6 +42,7 @@ debug "SFDX_INSTALL_PACKAGE_VERSION: $SFDX_INSTALL_PACKAGE_VERSION"
 debug "SFDX_CREATE_PACKAGE_VERSION: $SFDX_CREATE_PACKAGE_VERSION"
 debug "SFDX_PACKAGE_NAME: $SFDX_PACKAGE_NAME"
 debug "SFDX_PACKAGE_VERSION_ID: $SFDX_PACKAGE_VERSION_ID"
+debug "SFDX_PACKAGE_ID: $SFDX_PACKAGE2_VERSION_ID"
 
 whoami=$(whoami)
 debug "WHOAMI: $whoami"
@@ -115,8 +116,9 @@ if [ ! "$STAGE" == "REVIEW" ]; then
         auth "$vendorDir/sfdxurl" "$SFDX_DEV_HUB_AUTH_URL" d huborg
 
         log "Releasing package version $SFDX_PACKAGE_NAME ..."
-        # create package version
+        # release package
         CMD="sfdx force:package2:version:create:get -i $SFDX_PACKAGE2_VERSION_ID --json | jq -r .result.Package2VersionId"
+        debug "Create package release: $CMD"
         SFDX_VERSION_ID=$(eval $CMD)
         debug "SFDX_VERSION_ID: $SFDX_VERSION_ID"
         invokeCmd "sfdx force:package2:version:update -i \"$SFDX_VERSION_ID\"  --setasreleased --noprompt"

--- a/lib/release.sh
+++ b/lib/release.sh
@@ -61,8 +61,8 @@ debug "show_scratch_org_url: $show_scratch_org_url"
 debug "open-path: $open_path"
 debug "data-plans: $data_plans"
 
-# If review app or CI
-if [ "$STAGE" == "" ]; then
+# If review app or CI -- Added "STAGE"; "REVIEW" in app.json
+if [ "$STAGE" == "REVIEW" ]; then
 
   log "Running as a REVIEW APP ..."
   if [ ! "$CI" == "" ]; then
@@ -93,7 +93,7 @@ if [ "$STAGE" == "" ]; then
 fi
 
 # If Development, Staging, or Prod
-if [ ! "$STAGE" == "" ]; then
+if [ ! "$STAGE" == "REVIEW" ]; then
 
   log "Detected $STAGE. Kicking off deployment ..."
 

--- a/lib/release.sh
+++ b/lib/release.sh
@@ -9,6 +9,7 @@ unset GIT_DIR       # Avoid GIT_DIR leak from previous build steps
 
 TARGET_SCRATCH_ORG_ALIAS=${1:-}
 SFDX_PACKAGE_VERSION_ID=${2:-}
+SFDX_PACKAGE2_VERSION_ID=${3:-}
 
 vendorDir="vendor/sfdx"
 
@@ -114,8 +115,11 @@ if [ ! "$STAGE" == "REVIEW" ]; then
         auth "$vendorDir/sfdxurl" "$SFDX_DEV_HUB_AUTH_URL" d huborg
 
         log "Releasing package version $SFDX_PACKAGE_NAME ..."
-
-        invokeCmd "sfdx force:package2:version:update -i \"$SFDX_PACKAGE_VERSION_ID\"  --setasreleased --noprompt"
+        # create package version
+        CMD="sfdx force:package2:version:create:get -i $SFDX_PACKAGE2_VERSION_ID --json | jq -r .result.Package2VersionId"
+        SFDX_VERSION_ID=$(eval $CMD)
+        debug "SFDX_VERSION_ID: $SFDX_VERSION_ID"
+        invokeCmd "sfdx force:package2:version:update -i \"$SFDX_VERSION_ID\"  --setasreleased --noprompt"
         
       fi
       


### PR DESCRIPTION
I change the package installation command and added --noprompt. In my case I installed the Dreamhouse package into a clean org and got the question to accept remote sites, this halted the package installation. With the --noprompt the package installs fine.

I also added a changed the STAGE check to check for $STAGE = "REVIEW" instead of "". This assumes aap.json contains "STAGE": "REVIEW" in the ENV section when using Review Apps. The "" check works  fine but failed in my case when Heroku generated the app.json since then it assumes inheritance of the ENV variables.