### PR TITLE
Release package version (05i) to install to production

### DIFF
--- a/lib/release.sh
+++ b/lib/release.sh
@@ -102,6 +102,9 @@ if [ ! "$STAGE" == "" ]; then
   if [ "$SFDX_INSTALL_PACKAGE_VERSION" == "true" ] 
   then
 
+    # Auth to Dev Hub
+    auth "$vendorDir/sfdxurl" "$SFDX_DEV_HUB_AUTH_URL" d huborg
+
     pkgVersionInstallScript=bin/package-install.sh
     # run package install
     if [ ! -f "$pkgVersionInstallScript" ];
@@ -110,15 +113,21 @@ if [ ! "$STAGE" == "" ]; then
       # if target stage is production, release the package version
       if [ "$STAGE" == "PROD" ]; then
       
+        # get package version id (05i)
+        CMD="sfdx force:package2:version:list --json | jq '.result[] | select((.SubscriberPackageVersionId) == \"$SFDX_PACKAGE_VERSION_ID\")' | jq -r .Id"
+        debug "CMD: $CMD"
+        SFDX_PACKAGE_ID=$(eval $CMD)
+        debug "SFDX_PACKAGE_ID: $SFDX_PACKAGE_ID"
+      
         log "Set package version as released ..."
 
-        invokeCmd "sfdx force:package:update -i \"$SFDX_PACKAGE_VERSION_ID\" --noprompt --setasreleased"
+        invokeCmd "sfdx force:package2:version:update -i \"$SFDX_PACKAGE_ID\" --noprompt --setasreleased"
 
-      fi
-
+      fi    
+    
       log "Installing package version $SFDX_PACKAGE_NAME ..."
 
-      invokeCmd "sfdx force:package:install -i \"$SFDX_PACKAGE_VERSION_ID\" -u \"$TARGET_SCRATCH_ORG_ALIAS\" --wait 1000 --publishwait 1000"
+      invokeCmd "sfdx force:package:install --noprompt -i \"$SFDX_PACKAGE_VERSION_ID\" -u \"$TARGET_SCRATCH_ORG_ALIAS\" --wait 1000 --publishwait 1000"
 
     else
 


### PR DESCRIPTION
Have validated these changes in scratch orgs (review, development, staging stages) and an Enterprise org (production stage). All orgs are GS0 (Summer '18).

Summary of Changes
---
* Auths to Dev Hub so can run the `force:package2:version:update` command
* Look up the package version id (05i) to update based on the subscriber package version id (04t)
* To set package version released, use `force:package2:version:update` command instead of `force:package:update`