### PR TITLE
Fryan allow procfile

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -253,7 +253,7 @@ if [ ! -f $BUILD_DIR/Procfile ]; then
   debug "Generated Procfile that will deploy source in release phase and redirect to open-path in web phase"
 else
   log "Appending release phase to existing Procfile ..."
-  echo "# Deploy source to production org.
+  echo "\n# Deploy source to production org.
   release: ./"$vendorDir"/release.sh \"$TARGET_SCRATCH_ORG_ALIAS\" \"$SFDX_PACKAGE_VERSION_ID\"" >> $BUILD_DIR/Procfile
   debug "FRYAN existing Procfile should now also contain a release phase with necessary actions to perform."
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -253,7 +253,8 @@ if [ ! -f $BUILD_DIR/Procfile ]; then
   debug "Generated Procfile that will deploy source in release phase and redirect to open-path in web phase"
 else
   log "Appending release phase to existing Procfile ..."
-  echo "\n# Deploy source to production org.
+  echo " 
+  # Deploy source to production org.
   release: ./"$vendorDir"/release.sh \"$TARGET_SCRATCH_ORG_ALIAS\" \"$SFDX_PACKAGE_VERSION_ID\"" >> $BUILD_DIR/Procfile
   debug "FRYAN existing Procfile should now also contain a release phase with necessary actions to perform."
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -249,9 +249,13 @@ fi
 if [ ! -f $BUILD_DIR/Procfile ]; then
   log "Creating Procfile ..."
   echo "# Deploy source to production org.
-release: ./"$vendorDir"/release.sh \"$TARGET_SCRATCH_ORG_ALIAS\" \"$SFDX_PACKAGE_VERSION_ID\"" > $BUILD_DIR/Procfile
-
+  release: ./"$vendorDir"/release.sh \"$TARGET_SCRATCH_ORG_ALIAS\" \"$SFDX_PACKAGE_VERSION_ID\"" > $BUILD_DIR/Procfile
   debug "Generated Procfile that will deploy source in release phase and redirect to open-path in web phase"
+else
+  log "Appending release phase to existing Procfile ..."
+  echo "# Deploy source to production org.
+  release: ./"$vendorDir"/release.sh \"$TARGET_SCRATCH_ORG_ALIAS\" \"$SFDX_PACKAGE_VERSION_ID\"" >> $BUILD_DIR/Procfile
+  debug "FRYAN existing Procfile should now also contain a release phase with necessary actions to perform."
 fi
 
 # copy scripts needed for release phase

--- a/lib/release.sh
+++ b/lib/release.sh
@@ -60,6 +60,7 @@ debug "delete-scratch-org: $delete_scratch_org"
 debug "show_scratch_org_url: $show_scratch_org_url"
 debug "open-path: $open_path"
 debug "data-plans: $data_plans"
+debug "import-data: $import_data"
 
 # If review app or CI
 if [ "$STAGE" == "" ]; then
@@ -79,7 +80,7 @@ if [ "$STAGE" == "" ]; then
   auth "$scratchSfdxAuthUrlFile" "" s "$TARGET_SCRATCH_ORG_ALIAS"
 
   # Push source
-  invokeCmd "sfdx force:source:push -u $TARGET_SCRATCH_ORG_ALIAS"
+  invokeCmd "sfdx force:source:push --forceoverwrite -u $TARGET_SCRATCH_ORG_ALIAS"
 
   # Show scratch org URL
   if [ "$show_scratch_org_url" == "true" ]; then
@@ -88,6 +89,14 @@ if [ "$STAGE" == "" ]; then
     else
       invokeCmd "sfdx force:org:open -r"
     fi
+  fi
+
+  if [ "$assign_permset" == "true" ]; then
+    invokeCmd "sfdx force:user:permset:assign -n $permset_name -u $TARGET_SCRATCH_ORG_ALIAS"
+  fi
+
+  if [ "$import_data" == "true" ]; then
+    invokeCmd "sfdx force:data:tree:import -f $data_plans"
   fi
 
 fi


### PR DESCRIPTION
This is one part of how to address https://github.com/heroku/salesforce-buildpack/issues/32

It allows us to run a simple Python server which performs some log parsing of the latest Release logs and captures the logon URL for the Scratch org.

It then serves this URL as a link.